### PR TITLE
Persistent-keepalive is a very different concept from generic "keep-alive"

### DIFF
--- a/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/persistent-keepalive/node.def
+++ b/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/persistent-keepalive/node.def
@@ -1,5 +1,5 @@
 type: u32
-help: How often to send keep-alive packets
+help: Only useful when trying to maintain a connection from behind NAT, how often to send persistent keepalive packets
 
 syntax:expression: $VAR(@) > 0 && $VAR(@) < 65536;
                    "Value must be between 1 and 65535 seconds"


### PR DESCRIPTION
In general the naming scheme of wg(8) needs to be carried through to a vyatta module.

This naming scheme was discussed extensively on the mailing list back when it was introduce. Please stick with it.