### PR TITLE
Keys must be 44 characters and end in a =

### DIFF
--- a/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -4,8 +4,8 @@ help: Peer public key
 
 val_help: Base64 encoded public key
 
-syntax:expression: pattern $VAR(@) "^[0-9a-zA-Z\+/=]+$" ;
-	"Key is not valid Base64"
+syntax:expression: pattern $VAR(@) "^[0-9a-zA-Z\+/]{43}=$" ;
+	"Key is not valid 44-character (32-bytes) base64"
 
 create:
 	sudo wg set $VAR(../@) peer "$VAR(@)"


### PR DESCRIPTION
This is because they're 32-bytes of base64, always.