### PR TITLE
Add generate commands for WireGuard private and preshared keys

### DIFF
--- a/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/node.def
+++ b/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/node.def
@@ -1,0 +1,1 @@
+help: WireGuard key generation tool

--- a/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/preshared-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/preshared-key/node.def
@@ -1,0 +1,1 @@
+help: Generate WireGuard preshared key

--- a/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/preshared-key/node.tag/node.def
+++ b/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/preshared-key/node.tag/node.def
@@ -1,0 +1,27 @@
+help: Generate WireGuard preshared key with specified file name
+run:
+     result=1;
+     key_path=$5
+     full_path=
+
+     # Prepend /config/auth if the path is not absolute
+     if echo $key_path | egrep -ve '^/.*' > /dev/null; then
+         full_path=/config/auth/$key_path
+     else
+         full_path=$key_path
+     fi
+
+     key_dir=`dirname $full_path`
+     if [ ! -d $key_dir ]; then
+         echo "Directory $key_dir does not exist!"
+         exit 1
+     fi
+
+     echo "Generating WireGuard preshared key to $full_path"
+     sudo sh -c "umask 077; /usr/bin/wg genpsk > ${full_path}"
+     result=$?
+     if [ $result = 0 ]; then
+       echo "Your new WireGuard preshared key has been generated"
+     fi
+     /opt/vyatta/sbin/check_file_in_config_dir "$full_path" '/config/auth'
+allowed: echo -n '<filename>'

--- a/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/private-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/private-key/node.def
@@ -1,0 +1,1 @@
+help: Generate WireGuard private key

--- a/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/private-key/node.tag/node.def
+++ b/generic/opt/vyatta/share/vyatta-op/templates/generate/vpn/wireguard/private-key/node.tag/node.def
@@ -1,0 +1,27 @@
+help: Generate WireGuard private key with specified file name
+run:
+     result=1;
+     key_path=$5
+     full_path=
+
+     # Prepend /config/auth if the path is not absolute
+     if echo $key_path | egrep -ve '^/.*' > /dev/null; then
+         full_path=/config/auth/$key_path
+     else
+         full_path=$key_path
+     fi
+
+     key_dir=`dirname $full_path`
+     if [ ! -d $key_dir ]; then
+         echo "Directory $key_dir does not exist!"
+         exit 1
+     fi
+
+     echo "Generating WireGuard private key to $full_path"
+     sudo sh -c "umask 077; /usr/bin/wg genkey > ${full_path}"
+     result=$?
+     if [ $result = 0 ]; then
+       echo "Your new WireGuard private key has been generated"
+     fi
+     /opt/vyatta/sbin/check_file_in_config_dir "$full_path" '/config/auth'
+allowed: echo -n '<filename>'


### PR DESCRIPTION
Wrap `wg genkey` and `wg genpsk` to add `generate vpn wireguard private-key` and `generate vpn wireguard preshared-key`. Each takes a filename as a parameter. If a full path is given the key file will be saved to the full path. Otherwise it is saved to the /config/auth directory with the provided filename.
