### PR TITLE
Add ability to "disable" a peer

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -7,7 +7,30 @@ val_help: Base64 encoded public key
 syntax:expression: pattern $VAR(@) "^[0-9a-zA-Z\+/]{43}=$" ;
 	"Key is not valid 44-character (32-bytes) base64"
 
-create:
-	sudo wg set $VAR(../@) peer "$VAR(@)"
-delete:
-	sudo wg set $VAR(../@) peer "$VAR(@)" remove
+end:
+        if [ "$COMMIT_ACTION" = DELETE ] || [ -n "$VAR(./disable)" ]; then
+          if [[ $(sudo wg show "$VAR(../@)" peers) == *"$VAR(@)"* ]]; then
+            sudo wg set $VAR(../@) peer "$VAR(@)" remove
+          fi
+        else
+          sudo wg set $VAR(../@) peer $VAR(@)
+
+          ALLOWED=$(echo "$VAR(./allowed-ips/@)" | tr ' ' ',' | tr -d "'")
+          sudo wg set $VAR(../@) peer $VAR(@) allowed-ips "$ALLOWED"
+
+          if [ -n "$VAR(./endpoint)" ]; then
+            sudo wg set $VAR(../@) peer $VAR(@) endpoint "$VAR(./endpoint/@)"
+          fi
+
+          if [ -n "$VAR(../persistent-keepalive)" ]; then
+            sudo wg set $VAR(../@) peer $VAR(@) persistent-keepalive $VAR(./persistent-keepalive/@)
+          else
+            sudo wg set $VAR(../@) peer $VAR(@) persistent-keepalive 0
+          fi
+
+          if [ -n "$VAR(./preshared-key)" ]; then
+            echo "$VAR(./preshared-key/@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../@) peer $VAR(@) preshared-key <(echo "$key"); else wg set $VAR(../@) peer $VAR(@) preshared-key "$key"; fi'
+          else
+            sudo wg set $VAR(../@) peer $VAR(@) preshared-key /dev/null
+          fi
+        fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
@@ -1,15 +1,3 @@
 multi:
 type: txt
 help: Allow connections from these IP addresses
-
-create:
-	ALLOWED=`cli-shell-api returnValues interfaces wireguard $VAR(../../@) peer $VAR(../@) allowed-ips | tr ' ' ',' | tr -d "'"`
-	sudo wg set $VAR(../../@) peer $VAR(../@) allowed-ips "$ALLOWED"
-
-delete:
-	ALLOWED=`cli-shell-api returnValues interfaces wireguard $VAR(../../@) peer $VAR(../@) allowed-ips | tr ' ' ',' | tr -d "'"`
-	sudo wg set $VAR(../../@) peer $VAR(../@) allowed-ips "$ALLOWED"
-
-update:
-	ALLOWED=`cli-shell-api returnValues interfaces wireguard $VAR(../../@) peer $VAR(../@) allowed-ips | tr ' ' ',' | tr -d "'"`
-	sudo wg set $VAR(../../@) peer $VAR(../@) allowed-ips "$ALLOWED"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/disable/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/disable/node.def
@@ -1,0 +1,1 @@
+help: Disable peer

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/endpoint/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/endpoint/node.def
@@ -1,8 +1,3 @@
 priority: 9999
 type: txt
 help: Remote endpoint
-
-create:
-	sudo wg set $VAR(../../@) peer $VAR(../@) endpoint "$VAR(@)"
-update:
-	sudo wg set $VAR(../../@) peer $VAR(../@) endpoint "$VAR(@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/persistent-keepalive/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/persistent-keepalive/node.def
@@ -3,10 +3,3 @@ help: Only useful when trying to maintain a connection from behind NAT, how ofte
 
 syntax:expression: $VAR(@) > 0 && $VAR(@) < 65536;
                    "Value must be between 1 and 65535 seconds"
-
-create:
-	sudo wg set $VAR(../../@) peer $VAR(../@) persistent-keepalive $VAR(@)
-delete:
-	sudo wg set $VAR(../../@) peer $VAR(../@) persistent-keepalive 0
-update:
-	sudo wg set $VAR(../../@) peer $VAR(../@) persistent-keepalive $VAR(@)

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
@@ -1,10 +1,3 @@
 type: txt
 help: Optional preshared key
 val_help: File in /config/auth or 44-character (32-bytes) base64
-
-create:
-	echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../../@) peer $VAR(../@) preshared-key <(echo "$key"); else wg set $VAR(../../@) peer $VAR(../@) preshared-key "$key"; fi'
-delete:
-	sudo wg set $VAR(../../@) peer $VAR(../@) preshared-key /dev/null
-update:
-	echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../../@) peer $VAR(../@) preshared-key <(echo "$key"); else wg set $VAR(../../@) peer $VAR(../@) preshared-key "$key"; fi'


### PR DESCRIPTION
This adds the ability to disable a peer. Since WireGuard doesn't actually allow you to disable a peer this patch removes the peer from the WireGuard interface when the peer is disabled in the configuration. When the peer is again enabled the peer is added back to the WireGuard interface.

To accomplish this the `create`, `delete` and `update` sections from the node.def files of the sub-nodes of `peer` were removed and all processing of peer commands moved to the `end` section of the `peer` node.def. This seemed easier to maintain versus wrapping things in `if [ -n "$VAR(../disable)" ]` statements throughout the various node.def files.

The syntax to disable a peer is `interfaces wireguard <interface> peer <peerid> disable`.

While testing the patch I discovered that removing a preshared-key doesn't currently work. This turned out to be a bug in the `wg` tool. The bug was reported and Jason has already fixed it. It will be in the next snapshot after 0.0.20171122.