### PR TITLE
Fix upgrading from versions prior to Interface.pm changes

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -1,3 +1,6 @@
 #!/bin/sh
-dpkg-divert --package wireguard  --rename --remove \
-            /opt/vyatta/share/perl5/Vyatta/Interface.pm
+if [ "$1" = "remove" -o "$1" = "abort-install" -o "$1" = "disappear" ] \
+    && [ -n "$(dpkg-divert --list wireguard)" ]; then
+  dpkg-divert --package wireguard  --rename --remove \
+              /opt/vyatta/share/perl5/Vyatta/Interface.pm
+fi

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,4 +1,7 @@
 #!/bin/sh
-dpkg-divert --package wireguard --rename \
-            --divert /opt/vyatta/share/perl5/Vyatta/Interface.pm.vyatta \
-            --add /opt/vyatta/share/perl5/Vyatta/Interface.pm
+
+if [ "$1" = "install" ] || dpkg --compare-versions "$(dpkg-query --showformat='${Version}' --show wireguard)" lt "0.0.20171111-1"; then
+  dpkg-divert --package wireguard --rename \
+              --divert /opt/vyatta/share/perl5/Vyatta/Interface.pm.vyatta \
+              --add /opt/vyatta/share/perl5/Vyatta/Interface.pm
+fi


### PR DESCRIPTION
Fixes #25 

Makes changes to postrm and preinst to address a few issues with dpkg-divert. preinst will now only create the diversion if it as run as part of an install or if upgrading from before version 0.0.20171111-1 where the diversion was first introduced. This change stops the spurious messages about preserving the diversion that happens during an upgrade. 

postrm now only attempts to remove the diversion if it already exists. It it exists during a remove, abort-install and disappear action will remove the diversion. 