### PR TITLE
Fix private-key and preshared-key failing on ER-X when value is a string

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -29,7 +29,7 @@ end:
           fi
 
           if [ -n "$VAR(./preshared-key)" ]; then
-            echo "$VAR(./preshared-key/@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../@) peer $VAR(@) preshared-key <(echo "$key"); else wg set $VAR(../@) peer $VAR(@) preshared-key "$key"; fi'
+            echo "$VAR(./preshared-key/@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) peer $VAR(@) preshared-key /proc/self/fd/$FD; else wg set $VAR(../@) peer $VAR(@) preshared-key "$key"; fi'
           else
             sudo wg set $VAR(../@) peer $VAR(@) preshared-key /dev/null
           fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/private-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/private-key/node.def
@@ -3,6 +3,6 @@ help: Private key
 val_help: File in /config/auth or 44-character (32-bytes) base64
 
 create:
-	echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../@) private-key <(echo "$key"); else wg set $VAR(../@) private-key "$key"; fi'
+        echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) private-key /proc/self/fd/$FD; else wg set $VAR(../@) private-key "$key"; fi'
 update:
-	echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then wg set $VAR(../@) private-key <(echo "$key"); else wg set $VAR(../@) private-key "$key"; fi'
+        echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) private-key /proc/self/fd/$FD; else wg set $VAR(../@) private-key "$key"; fi'


### PR DESCRIPTION
Fix for issue #9 

Don't know if you want to merge this or wait for the release of the 1.10 firmware. Instead of using process substitution this patch creates a file descriptor, FD, echoing the key string to it. wg then sets the key from /proc/self/fd/$FD. 