### PR TITLE
Verify allowed-ips values and check for duplicate assignments

### DIFF
--- a/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
+++ b/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
@@ -1,0 +1,120 @@
+#!/usr/bin/perl
+
+use lib "/opt/vyatta/share/perl5/";
+use Vyatta::Config;
+
+use NetAddr::IP qw(:lower);
+use Getopt::Long;
+
+use strict;
+
+sub usage {
+    print <<EOF;
+Usage: $0 --intf <interface>
+       $0 --intf <interface> --peer <peer>
+       $0  --allowed-ips <ip_address ...>
+EOF
+    exit 1;
+}
+
+my ($intf, $peer, @allowed_ips);
+
+GetOptions("intf=s"           => \$intf,
+           "peer=s"           => \$peer,
+           "allowed-ips=s{,}" => \@allowed_ips,
+) or usage();
+
+is_valid_allowed_ips(@allowed_ips) if @allowed_ips;
+is_valid_peer($intf, $peer) if $peer && $intf;
+is_valid_interface($intf, $peer) if $intf && !$peer && !@allowed_ips;
+
+exit 0;
+
+# Validate that allowed-ips are assigned to only one peer on an interface
+sub is_valid_interface {
+    my ($intf) = @_;
+    my @allowed_ips;
+    my $config = new Vyatta::Config;
+    my $path = "interfaces wireguard ${intf}";
+    die "${0} error: invlaid interface\n" unless $config->exists($path);
+
+    # Get allowed-ips for all peers on the interface
+    $config->setLevel("${path} peer");
+    push @allowed_ips, get_peer_allowed_ips("${path} peer ${_}") for $config->listNodes();
+
+    # Get array containing any duplicate members of @allowed_ips
+    my @duplicates = duplicates(@allowed_ips);
+    
+    # If there are duplicates raise an error message for each and die.
+    # IPv6 addresses are converted to their short format to comply with RFC5952
+    if (@duplicates) {
+        my $err_str;
+        foreach (@duplicates) {
+            $err_str .= "Error: Allowed IP " . ($_->version() == 4 ? $_ : $_->short()) . " assigned to multiple peers on interface ${intf}\n";
+        }
+        die $err_str;
+    }
+    return; 
+}
+
+# Validate that peer doesn't contain duplicate allowed-ips
+sub is_valid_peer {
+    my ($intf, $peer) = @_;
+    my $config = new Vyatta::Config;
+    my $path = "interfaces wireguard ${intf} peer ${peer}";
+    die "${0} error: invlaid interface and/or peer\n" unless $config->exists($path);
+    
+    # Get allowed-ips for the peer
+    @allowed_ips = get_peer_allowed_ips($path);
+    
+    # Get array containing any duplicate members of @allowed_ips
+    my @duplicates = duplicates(@allowed_ips);
+    
+    # If there are duplicates raise an error message for each and die.
+    # IPv6 addresses are converted to their short format to comply with RFC5952
+    if (@duplicates) {
+        my $err_str;
+        foreach (@duplicates) {
+            $err_str .= "Error: Allowed IP " . ($_->version() == 4 ? $_ : $_->short()) . " appears multiple times on interface ${intf} peer ${peer}\n";
+        }
+        die $err_str;
+    }
+    
+    return;
+}
+
+# Validate that the allowed-ips list provided contains valid ip addresses
+sub is_valid_allowed_ips {
+    my (@allowed_ips, $print_ips) = @_;
+    @allowed_ips = split(/,/,join(',',@allowed_ips));
+
+    for (@allowed_ips) {
+        my $ip = new NetAddr::IP->new($_);
+        die "Error: Allowed IP ${_} is not a valid IP address\n" unless $ip;
+    }
+
+    return;
+}
+
+# Get an array containing all allowed-ips assigned to a peer
+sub get_peer_allowed_ips {
+    my ($peer) = @_;
+    my @allowed_ips;
+
+    my $config = new Vyatta::Config;
+    $config->setLevel($peer);
+    my @peer_allowed_ips = $config->returnValues("allowed-ips");
+    foreach (@peer_allowed_ips) {
+        push @allowed_ips, new NetAddr::IP->new($_) for split(/,/, $_);    
+    }
+    
+    return @allowed_ips;
+}
+
+# Return an array containing any non-unique members of the provided array
+sub duplicates {
+    my (@array) = @_;
+    my %seen;
+    
+    return grep { $seen{ $_ }++ } @array;
+}

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.def
@@ -29,3 +29,5 @@ end: if [ "$COMMIT_ACTION" != DELETE ]; then
 
 commit:expression: $VAR(./private-key) != "" ;
 	"Private key must be specified for $VAR(@)"
+
+commit:expression: exec "${vyatta_sbindir}/vyatta-check-allowed-ips.pl --intf $VAR(@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -7,6 +7,8 @@ val_help: Base64 encoded public key
 syntax:expression: pattern $VAR(@) "^[0-9a-zA-Z\+/]{43}=$" ;
 	"Key is not valid 44-character (32-bytes) base64"
 
+commit:expression: exec "${vyatta_sbindir}/vyatta-check-allowed-ips.pl --intf $VAR(../@) --peer $VAR(@)"
+
 end:
         if [ "$COMMIT_ACTION" = DELETE ] || [ -n "$VAR(./disable)" ]; then
           if [[ $(sudo wg show "$VAR(../@)" peers) == *"$VAR(@)"* ]]; then

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
@@ -1,3 +1,5 @@
 multi:
 type: txt
-help: Allow connections from these IP addresses
+help: IP addresses allowed to traverse the peer
+val_help: <ip1>/<cidr1>[,<ip2>/<cidr2>]
+syntax:expression: exec "${vyatta_sbindir}/vyatta-check-allowed-ips.pl --allowed-ips $VAR(@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
@@ -1,5 +1,7 @@
 multi:
 type: txt
 help: IP addresses allowed to traverse the peer
-val_help: <ip1>/<cidr1>[,<ip2>/<cidr2>]
-syntax:expression: exec "${vyatta_sbindir}/vyatta-check-allowed-ips.pl --allowed-ips $VAR(@)"
+val_help: <x.x.x.x/x | h:h:h:h:h:h:h:h>[,x.x.x.x/x | h:h:h:h:h:h:h:h]...; Comma separated list of IP addresses to allow
+
+syntax:expression: exec "ips=$VAR(@); for ip in ${ips//,/ }; do /opt/vyatta/sbin/vyatta-find-type.pl $ip ipv4net ipv4 ipv6net ipv6 > /dev/null; done || exit 1";
+                   "Value must contain valid IP addresses"


### PR DESCRIPTION
This PR verifies the correctness of `allowed-ips` statements in 3 ways. 

1. When an `allowed-ips` statement is entered it is immediately checked to assure it consists of valid ip addresses
2. At commit time each peer is checked to make sure it doesn't contain any duplicate allowed ip addresses. Duplicating allowed ip addresses on a peer wouldn't have any impact on actual behavior versus expected behavior, but doing this validation makes the logic for the next step easier and there is no reason to have the same allowed ip address assigned to the same peer multiple times. 
3. At commit time each interface is checked to make sure no peers on the interface have any matching allowed ip addresses. This could impact actual versus expected behavior. If peers on the same interface have matching allowed ip addresses in their configuration the address will end up being applied to the last peer to be configured during the commit process. This may not be what was intended and the router configuration should be deterministic.

All allowed ip addresses are converted to perl NetAddr:IP values before being compared, so IP addresses that equate to the same value but are entered differently will be properly matched. For example `assigned-ips 10.10.10.10` and `assigned-ips 10.10.10.10/32` will match.