### PR TITLE
Verify key file exists and simplify passing of base64 key to wg

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -31,7 +31,11 @@ end:
           fi
 
           if [ -n "$VAR(./preshared-key)" ]; then
-            echo "$VAR(./preshared-key/@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) peer $VAR(@) preshared-key /proc/self/fd/$FD; else wg set $VAR(../@) peer $VAR(@) preshared-key "$key"; fi'
+            if [[ $VAR(./preshared-key/@) =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then
+              echo $VAR(./preshared-key/@) | sudo wg set $VAR(../@) peer $VAR(@) preshared-key /proc/self/fd/0
+            else
+              sudo wg set $VAR(../@) peer $VAR(@) preshared-key $VAR(./preshared-key/@)
+            fi
           else
             sudo wg set $VAR(../@) peer $VAR(@) preshared-key /dev/null
           fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
@@ -1,3 +1,8 @@
 type: txt
 help: Optional preshared key
-val_help: File in /config/auth or 44-character (32-bytes) base64
+val_help: txt; 44-character (32-bytes) base64 key
+val_help: txt; Key file in /config/auth
+val_help: txt; Full path to key file
+
+syntax:expression: exec "if [[ !($VAR(@) =~ ^[0-9a-zA-Z/+]{43}=$) ]]; then key=$VAR(@); if [[ ${key} = ${key%/*} ]]; then key=\"/config/auth/$key\"; fi; [ -e $key ]; exit; fi";
+                   "Pre-shared key file $VAR(@) not found"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/private-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/private-key/node.def
@@ -1,8 +1,25 @@
 type: txt
 help: Private key
-val_help: File in /config/auth or 44-character (32-bytes) base64
+val_help: txt; 44-character (32-bytes) base64 key
+val_help: txt; Key file in /config/auth
+val_help: txt; Full path to key file
 
+syntax:expression: exec "if [[ !($VAR(@) =~ ^[0-9a-zA-Z/+]{43}=$) ]]; then key=$VAR(@); if [[ ${key} = ${key%/*} ]]; then key=\"/config/auth/$key\"; fi; [ -e $key ]; exit; fi";
+                   "Private key file $VAR(@) not found"
 create:
-        echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) private-key /proc/self/fd/$FD; else wg set $VAR(../@) private-key "$key"; fi'
+        if [[ $VAR(@) =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then
+            echo $VAR(@) | sudo wg set $VAR(../@) private-key /proc/self/fd/0
+        else
+            key=$VAR(@)
+            if [[ $key = ${key%/*} ]]; then key="/config/auth/$key"; fi
+            sudo wg set $VAR(../@) private-key $key
+        fi
+
 update:
-        echo "$VAR(@)" | sudo bash -c 'read -r key; if [[ $key =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then exec {FD}<<< $(echo "$key"); wg set $VAR(../@) private-key /proc/self/fd/$FD; else wg set $VAR(../@) private-key "$key"; fi'
+        if [[ $VAR(@) =~ ^[0-9a-zA-Z/+]{43}=$ ]]; then
+            echo $VAR(@) | sudo wg set $VAR(../@) private-key /proc/self/fd/0
+        else
+            key=$VAR(@)
+            if [[ $key = ${key%/*} ]]; then key="/config/auth/$key"; fi
+            sudo wg set $VAR(../@) private-key $key
+        fi


### PR DESCRIPTION
This PR make changes to how private keys and preshared keys are applied. First it applies a syntax check to both to verify that checks that either the key file specified exists or the key is a base64 key. If a key file is specified doesn't contain a full path the /config/auth path will be checked for the file. This is especially important for the private-key because without it an invalid key entry would result in the configuration commit failing but the wireguard device being created. Correcting this required manually deleting the interface with a `ip link del dev wgN` command. 

The PR also simplifies applying a base64 key. Instead of using exec to create a file descriptor as previously done the base64 string is piped to stdin of the wg command and the wg command uses /proc/self/fd/0, which is the fd for stdin, as the key file.