### PR TITLE
Add missing 'then' in if statement for committing preshared key

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/preshared-key/node.def
@@ -5,4 +5,4 @@ val_help: txt; File in /config/auth
 
 syntax:expression: exec "if [[ !(\"$VAR(@)\" =~ ^[0-9a-zA-Z/+]{43}=$) ]]; then exec ${vyatta_sbindir}/check_file_in_config_dir $VAR(@) '/config/auth'; fi"
 
-commit:expression: exec "if [[ !(\"$VAR(@)\" =~ ^[0-9a-zA-Z/+]{43}=$) ]]; [[ -e $VAR(@) ]] || exit 1; fi" ; "Error: Preshared-key $VAR(@) not found"
+commit:expression: exec "if [[ !(\"$VAR(@)\" =~ ^[0-9a-zA-Z/+]{43}=$) ]]; then [[ -e $VAR(@) ]] || exit 1; fi" ; "Error: Preshared-key $VAR(@) not found"


### PR DESCRIPTION
The missing 'then' in the if statement results in an additional check that tries to verify the existence of a file with the preshared key as name.