### PR TITLE
Update ip & ipv6 configuration to use ubnt standard

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/md5/key-id/node.tag/md5-key/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/md5/key-id/node.tag/md5-key/node.def
@@ -2,19 +2,3 @@ type: txt
 help: MD5 key
 syntax:expression: pattern $VAR(@) "^[^[:space:]]{1,16}$"; "MD5 key must be 16 characters or less"
 val_help: MD5 Key (16 characters or less)
-
-# If this node is created 
-create:
-	vtysh -c "configure terminal" -c "interface $VAR(../../../../../../@)" \
-             -c "ip ospf message-digest-key $VAR(../@) md5 $VAR(@)"
-
-# If the value of this node is changed
-update:
-	vtysh -c "configure terminal" -c "interface $VAR(../../../../../../@)" \
-             -c "no ip ospf message-digest-key $VAR(../@)" \
-             -c "ip ospf message-digest-key $VAR(../@) md5 $VAR(@)"
-
-# If this node is deleted
-delete:
-        vtysh -c "configure terminal" -c "interface $VAR(../../../../../../@)" \
-             -c "no ip ospf message-digest-key $VAR(../@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/md5/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/md5/node.def
@@ -1,10 +1,1 @@
 help: MD5 parameters
-
-create: vtysh -c "configure terminal" \
-	-c "interface $VAR(../../../../@)" \
-	-c "no ip ospf authentication" \
-	-c "ip ospf authentication message-digest"
-
-delete: vtysh -c "configure terminal" \
-	-c "interface $VAR(../../../../@)" \
-        -c "no ip ospf authentication"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/plaintext-password/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/authentication/plaintext-password/node.def
@@ -2,9 +2,3 @@ type: txt
 help: Plain text password
 syntax:expression: pattern $VAR(@) "^[^[:space:]]{1,8}$" ; "Password must be 8 characters or less"
 val_help: Plain text password (8 characters or less)
-
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-	 -c "no ip ospf authentication " -c "ip ospf authentication " \
-	 -c "ip ospf authentication-key $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-	 -c "no ip ospf authentication " -c "no ip ospf authentication-key"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/bandwidth/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/bandwidth/node.def
@@ -1,7 +1,0 @@
-type: u32
-help: Bandwidth of interface (kilobits/sec)
-syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 10000000; "Must be between 1-10000000"
-val_help: u32:1-10000000; Bandwidth in kilobits/sec (for calculating OSPF cost)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "bandwidth $VAR(@)" 
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no bandwidth" 

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/cost/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/cost/node.def
@@ -2,10 +2,3 @@ type: u32
 help: Interface cost
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; OSPF interface cost
-
-update:vtysh -c "configure terminal" \
-	-c "interface $VAR(../../../@)" \
-	-c "ip ospf cost $VAR(@)"
-delete:vtysh -c "configure terminal" \
-	-c "interface $VAR(../../../@)" \
-	-c "no ip ospf cost"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/dead-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/dead-interval/node.def
@@ -3,6 +3,3 @@ help: Interval after which neighbor is dead
 default: 40
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; OSPF dead interval in seconds (default 40)
-
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf dead-interval $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf dead-interval"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/hello-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/hello-interval/node.def
@@ -3,6 +3,3 @@ help: Interval between hello packets
 default: 10
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Interval between OSPF hello packets in seconds (default 10)
-
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf hello-interval $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf hello-interval"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/mtu-ignore/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/mtu-ignore/node.def
@@ -1,3 +1,1 @@
 help: Disable Maximum Transmission Unit (MTU) mismatch detection
-create:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf mtu-ignore"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf mtu-ignore"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/network/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/network/node.def
@@ -2,8 +2,6 @@ type: txt
 help: Network type
 syntax:expression: $VAR(@) in "broadcast", "non-broadcast", "point-to-multipoint", "point-to-point"; \
        "Must be (broadcast|non-broadcast|point-to-multipoint|point-to-point)"
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf network $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf network"
 
 val_help: broadcast; Broadcast network type
 val_help: non-broadcast; Non-broadcast network type

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/node.def
@@ -1,1 +1,5 @@
 help: Open Shortest Path First (OSPF) parameters
+
+begin:   if ! /etc/init.d/vyatta-quagga status ospfd > /dev/null ; then
+            sudo /etc/init.d/vyatta-quagga start ospfd
+         fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/priority/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/priority/node.def
@@ -3,6 +3,3 @@ help: Router priority
 default: 1
 syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 255; "Must be between 0-255"
 val_help: u32:0-255; Priority (default 1)
-
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf priority $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf priority"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/retransmit-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/retransmit-interval/node.def
@@ -3,8 +3,3 @@ help: Interval between retransmitting lost link state advertisements
 default: 5
 syntax:expression: $VAR(@) >= 3 && $VAR(@) <= 65535; "Must be between 3-65535"
 val_help: u32: 3-65535; Retransmit interval in seconds (default 5)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-	-c "ip ospf retransmit-interval $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-	-c "no ip ospf retransmit-interval"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/transmit-delay/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/ospf/transmit-delay/node.def
@@ -3,6 +3,3 @@ help: Link state transmit delay
 default: 1
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Transmit delay in seconds (default 1)
-
-update:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ip ospf transmit-delay $VAR(@)"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ip ospf transmit-delay"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/authentication/md5/node.tag/password/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/authentication/md5/node.tag/password/node.def
@@ -2,16 +2,3 @@ type: txt
 help: Authentication password
 syntax:expression: pattern $VAR(@) "^[^[:space:]]{1,16}$" ; "MD5 key must be 16 characters or less"
 val_help: MD5 Key (16 characters or less)
-
-update:vtysh                                     \
-       -c "configure terminal" -c "interface $VAR(../../../../../@)"   \
-       -c "ip rip authentication mode md5"              \
-       -c "ip rip authentication key-chain $VAR(../../../../../@)-rip" \
-       -c "key chain $VAR(../../../../../@)-rip" -c "key $VAR(../@)"   \
-       -c "key-string $VAR(@)"
-
-delete:vtysh --noerror                              \
-       -c "configure terminal" -c "interface $VAR(../../../../../@)"      \
-       -c "no ip rip authentication mode md5"              \
-       -c "no ip rip authentication key-chain $VAR(../../../../../@)-rip" \
-       -c "no key chain $VAR(../../../../../@)-rip"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/authentication/plaintext-password/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/authentication/plaintext-password/node.def
@@ -3,11 +3,3 @@ help: Plain text password
 syntax:expression: pattern $VAR(@) "^[^[:space:]]{1,16}$" ; "Password must be 16 characters or less"
 commit:expression: $VAR(../md5/) == "" ; "md5 password already set"
 val_help: Password (16 characters or less)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-	-c "ip rip authentication mode text" \
-	-c "ip rip authentication string $VAR(@)"
-
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-	-c "no ip rip authentication mode" \
-	-c "no ip rip authentication string $VAR(@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/node.def
@@ -1,1 +1,5 @@
 help: Routing Information Protocol (RIP)
+
+begin: if ! /etc/init.d/vyatta-quagga status ripd > /dev/null ; then
+           sudo /etc/init.d/vyatta-quagga start ripd
+       fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/split-horizon/disable/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/split-horizon/disable/node.def
@@ -1,8 +1,3 @@
 help: Disable split horizon on specified interface
-create: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-    -c "no ip rip split-horizon"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-    -c "ip rip split-horizon"
-
 commit:expression: ($VAR(../poison-reverse/) == ""); \
     "You cannot have 'split-horizon poison-reverse' enabled with 'split-horizon' disabled for $VAR(../../../../@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/split-horizon/poison-reverse/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/rip/split-horizon/poison-reverse/node.def
@@ -1,9 +1,4 @@
 help: Enable poison reverse for split-horizon
-create:vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-       -c "ip rip split-horizon poisoned-reverse"
-
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-       -c "no ip rip split-horizon" -c "ip rip split-horizon "
 
 commit:expression: ($VAR(../disable/) == ""); \
     "You cannot have 'split-horizon poison-reverse' enabled with 'split-horizon' disabled for $VAR(../../../../@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/source-validation/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ip/source-validation/node.def
@@ -24,7 +24,7 @@ update:
         fi
 
         if [ "$all" -gt "$new" ]; then
-           echo "Warning: global source-validation overrides per interface"
+           echo "Warning: global soure-validation overrides per interface"
            global="disable"
            if [ "$all" -eq 1 ]; then
               global=strict
@@ -33,12 +33,8 @@ update:
            fi
            echo "Global value is $global"
         fi
-        if [ -d /sys/class/net/$VAR(../@) ] ; then
-                sudo sh -c "echo $new > \
-                       /proc/sys/net/ipv4/conf/$VAR(../../@)/rp_filter"
-        fi
+        sudo sh -c "echo $new > \
+               /proc/sys/net/ipv4/conf/$VAR(../../@)/rp_filter"
 
 delete:
-        if [ -d /sys/class/net/$VAR(../@) ] ; then
-                sudo sh -c "echo 0 > /proc/sys/net/ipv4/conf/$VAR(../../@)/rp_filter"
-        fi
+	sudo sh -c "echo 0 > /proc/sys/net/ipv4/conf/$VAR(../../@)/rp_filter"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/autoconf/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/autoconf/node.def
@@ -1,0 +1,25 @@
+#
+# This is a valueless node, hence has no type associated with it.
+#
+
+help: Enable acquisition of IPv6 address using stateless autoconfig
+
+update:
+	sudo touch /var/run/vyatta/ipv6.autoconf.$VAR(../../../@)
+	if [ -e /proc/sys/net/ipv6/conf/$VAR(../../../@)/autoconf ]; then
+	    echo "Enabling address auto-configuration for $VAR(../../../@)"
+	    sudo sh -c "echo 2 > /proc/sys/net/ipv6/conf/$VAR(../../../@)/accept_ra"
+        sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$VAR(../../../@)/autoconf"
+	else
+	    echo "Address auto-configuration will be enabled when interface comes up."
+	fi
+
+delete:
+	sudo rm -f /var/run/vyatta/ipv6.autoconf.$VAR(../../../@)
+	if [ -e /proc/sys/net/ipv6/conf/$VAR(../../../@)/autoconf ]; then
+	    sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$VAR(../../../@)/accept_ra"
+	    sudo sh -c "echo 0 > /proc/sys/net/ipv6/conf/$VAR(../../../@)/autoconf"
+	else
+	    echo "Address auto-configuration will be disabled when interface comes up."
+	fi
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/eui64/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/eui64/node.def
@@ -1,0 +1,15 @@
+multi:
+type: ipv6net
+help: Assign IPv6 address using EUI-64 based on MAC address
+
+val_help: <h:h:h:h/64>; 64-bit IPv6 prefix to use with EUI-64 to make address
+
+create:
+	if [ -e /proc/sys/net/ipv6/conf/$VAR(../../../@) ]; then
+	    sudo /opt/vyatta/sbin/vyatta-ipv6-eui64.pl --create $VAR(../../../@) $VAR(@)
+	else
+	    echo "EUI-64 based address will be assigned when interface comes up."
+	fi
+
+delete:
+	sudo /opt/vyatta/sbin/vyatta-ipv6-eui64.pl --delete $VAR(../../../@) $VAR(@)

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/address/node.def
@@ -1,0 +1,2 @@
+help: IPv6 address auto-configuration modes
+priority: 400

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/disable-forwarding/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/disable-forwarding/node.def
@@ -1,0 +1,31 @@
+
+help: Disable IPv6 forwarding on this interface only
+
+create:
+	procfile=/proc/sys/net/ipv6/conf/$VAR(../../@)/forwarding
+	if [ -e $procfile ]; then
+	    echo "Disabling IPv6 forwarding for $VAR(../../@)"
+	    sudo sh -c "echo 0 > $procfile"
+	else
+	    echo "IPv6 forwarding will be disabled when $VAR(../../@) comes up"
+	fi
+	touch /var/run/vyatta/ipv6_no_fwd.$VAR(../../@)
+
+delete:
+	procfile=/proc/sys/net/ipv6/conf/$VAR(../../@)/forwarding
+	if [ -e $procfile ]; then
+	    # Only re-enable forwarding if global disable-forwarding switch
+	    # is not set.
+	    global=`cat /proc/sys/net/ipv6/conf/default/forwarding`
+	    if [ "$global" = "1" ]; then
+		echo "Re-enabling IPv6 forwarding for $VAR(../../@)"
+		sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$VAR(../../@)/forwarding"
+	    else
+		echo "Not re-enabling IPv6 forwarding for $VAR(../../@) because it is still" 
+		echo "globally disabled."
+	    fi
+	else
+	    echo "IPv6 forwarding will be re-enabled when $VAR(../../@) comes up"
+	fi
+	rm /var/run/vyatta/ipv6_no_fwd.$VAR(../../@)
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/dup-addr-detect-transmits/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/dup-addr-detect-transmits/node.def
@@ -1,0 +1,18 @@
+type: u32
+help: Number of NS messages to send while performing DAD
+
+val_help: <1-N>; Number of NS messages to send while performing DAD
+val_help: 0; Disable Duplicate Address Dectection (DAD)
+
+default: 1
+
+syntax:expression: ($VAR(@) >= 0) ; "Value must be >= 0"
+
+update:
+        sudo sh -c "echo $VAR(@) >/var/run/vyatta/ipv6.dad.$VAR(../../@)"
+        procfile=/proc/sys/net/ipv6/conf/$VAR(../../@)/dad_transmits
+        if [ -e $procfile ]; then
+            sudo sh -c "echo $VAR(@) > $procfile"
+        else
+            echo "Will set dup_addr_detect_transmits when $VAR(../../@) comes up"
+        fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/cost/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/cost/node.def
@@ -3,6 +3,3 @@ help: Interface cost
 default: 1
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; OSPFv3 cost
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 cost $VAR(@)"
-

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/dead-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/dead-interval/node.def
@@ -3,8 +3,3 @@ help: Interval after which neighbor is declared dead
 default: 40
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Neighbor dead interval in seconds (default 40)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 dead-interval $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 dead-interval 40"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/hello-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/hello-interval/node.def
@@ -3,8 +3,3 @@ help: Interval between hello packets
 default: 10
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Interval between OSPFv3 hello packets in seconds (default 10)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 hello-interval $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 hello-interval 10"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/ifmtu/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/ifmtu/node.def
@@ -2,6 +2,3 @@ type: u32
 help: Interface MTU
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Interface MTU
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 ifmtu $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ipv6 ospf6 ifmtu"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/instance-id/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/instance-id/node.def
@@ -3,6 +3,3 @@ help: Instance-id
 default: 0
 syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 255; "Must be between 0-255"
 val_help: u32:0-255; Instance Id (default 0)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 instance-id $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 instance-id 0"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/mtu-ignore/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/mtu-ignore/node.def
@@ -1,4 +1,1 @@
 help: Disable Maximum Transmission Unit mismatch detection
-create:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 mtu-ignore"
-delete:vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ipv6 ospf6 mtu-ignore"
-

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/node.def
@@ -1,1 +1,5 @@
 help: IPv6 Open Shortest Path First (OSPFv3)
+
+begin:   if ! /etc/init.d/vyatta-quagga status ospf6d > /dev/null ; then
+           sudo /etc/init.d/vyatta-quagga start ospf6d
+         fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/passive/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/passive/node.def
@@ -1,3 +1,1 @@
 help: Disable forming of adjacency
-create: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 passive"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "no ipv6 ospf6 passive"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/priority/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/priority/node.def
@@ -3,6 +3,3 @@ help: Router priority
 default: 1
 syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 255; "Must be between 0-255"
 val_help: u32:0-255; Priority (default 1)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 priority $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" -c "ipv6 ospf6 priority 1"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/retransmit-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/retransmit-interval/node.def
@@ -3,8 +3,3 @@ help: Interval between retransmitting lost link state advertisements
 default: 5
 syntax:expression: $VAR(@) >= 3 && $VAR(@) <= 65535; "Must be between 3-65535"
 val_help: u32:3-65535; Retransmit interval in seconds (default 5)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 retransmit-interval $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 retransmit-interval 5"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/transmit-delay/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ospfv3/transmit-delay/node.def
@@ -3,8 +3,3 @@ help: Link state transmit delay
 default: 1
 syntax:expression: $VAR(@) >= 1 && $VAR(@) <= 65535; "Must be between 1-65535"
 val_help: u32:1-65535; Link state transmit delay (default 1)
-
-update: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 transmit-delay $VAR(@)"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../@)" \
-          -c "ipv6 ospf6 transmit-delay 1"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/node.def
@@ -1,1 +1,5 @@
 help: Routing Information Protocol (RIPng)
+
+begin: if ! /etc/init.d/vyatta-quagga status ripngd > /dev/null ; then
+           sudo /etc/init.d/vyatta-quagga start ripngd
+       fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/split-horizon/disable/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/split-horizon/disable/node.def
@@ -1,6 +1,4 @@
 help: Disable split horizon
-create: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" -c "no ipv6 ripng split-horizon"
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" -c "ipv6 ripng split-horizon"
 
 commit:expression: ($VAR(../poison-reverse/) == "");  \
     "You cannot have 'split-horizon poison-reverse' enabled with 'split-horizon' disabled for $VAR(../../../../@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/split-horizon/poison-reverse/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/ripng/split-horizon/poison-reverse/node.def
@@ -1,9 +1,4 @@
 help: Enable poison reverse for split-horizon
-create: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-          -c "ipv6 ripng split-horizon poisoned-reverse"
-
-delete: vtysh -c "configure terminal" -c "interface $VAR(../../../../@)" \
-          -c "no ipv6 ripng split-horizon" -c "ipv6 ripng split-horizon"
 
 commit:expression: ($VAR(../disable/) == ""); \
    "You cannot have 'split-horizon poison-reverse' enabled with 'split-horizon' disabled for $VAR(../../../../@)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/cur-hop-limit/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/cur-hop-limit/node.def
@@ -1,0 +1,10 @@
+type: u32
+help: Value to be placed in the "Current Hop Limit" field in RAs
+
+# Default value per Assignned Numbers RFC
+default: 64
+
+val_help: u32:1-255; Value to place in the "Current Hop Limit" field in RAs
+val_help: 0; Place 0, meaning "unspecified", in "Current Hop Limit" field
+
+syntax:expression: ($VAR(@) >= 0 && $VAR(@) <= 255) ; "Value must be between 0 and 255"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/default-lifetime/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/default-lifetime/node.def
@@ -1,0 +1,9 @@
+type: u32
+help: Value to be placed in "Router Lifetime" field in RAs
+
+# No default value.  Value will be determined algorithmically based on
+# value of MaxRtrAdvInterval if left unspecified by the user.
+
+val_help: u32:4-9000; Value in seconds to be placed in "Router Lifetime" field in RAs
+val_help: 0; Place 0, meaning "not a default router", in Router Lifetime field
+syntax:expression: ($VAR(@) == 0 || ($VAR(@) >= 4 && $VAR(@) <= 9000)) ; "Value must be 0 or between 4 and 9000"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/default-preference/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/default-preference/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Default router preference
+
+syntax:expression: $VAR(@) in "low", "medium", "high"; \
+       "Must be (low|medium|high)"
+
+val_help: low; Default router is low preference
+val_help: medium; Default router is medium preference (Default)
+val_help: high; Default router is high preference
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/link-mtu/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/link-mtu/node.def
@@ -1,0 +1,10 @@
+type: u32
+help: Value of link MTU to place in RAs
+
+# Default value per RFC-4861.
+default: 0
+
+val_help: <1-MAX>; Value of link MTU to place in RAs
+val_help: 0; Do not send MTU options in RAs
+
+syntax:expression: ($VAR(@) == 0 || $VAR(@) >= 1280) ; "Value must be 0 or 1280 or greater"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/managed-flag/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/managed-flag/node.def
@@ -1,0 +1,10 @@
+type: bool
+help: Value for "managed address configuration" flag in RAs
+
+# Default value per RFC-4861.
+default: false
+allowed: echo -n "true false"
+
+val_help: true; Place "true" in "managed address configuration" flag in RAs
+val_help: false; Place "false" in "managed address configuration" flag in RAs
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/max-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/max-interval/node.def
@@ -1,0 +1,9 @@
+type: u32
+help: Maximum interval between unsolicited multicast RAs
+
+# Default value per RFC-4861
+default: 600
+
+val_help: u32:4-1800; Maximum interval in seconds between unsolicited multicast RAs
+
+syntax:expression: ($VAR(@) >= 4 && $VAR(@) <= 1800) ; "Value must be between 4 and 1800"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/min-interval/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/min-interval/node.def
@@ -1,0 +1,10 @@
+type: u32
+help: Minimum interval between unsolicited multicast RAs
+
+# No default value.  Value will be determined algorithmically based
+# on the value of MaxRtrAdvInterval if not set by the user. Algorithm
+# is specified in RFC-4861.
+
+val_help: u32:3-1350; Minimum interval in seconds between unsolicited multicast RAs
+
+syntax:expression: ($VAR(@) >= 3 && $VAR(@) <= 1350) ; "Value must be between 3 and 1350"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/name-server/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/name-server/node.def
@@ -1,0 +1,6 @@
+
+multi:
+
+type: ipv6
+
+help: IPv6 address of a Recursive DNS Server

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/node.def
@@ -1,0 +1,37 @@
+
+priority: 999 # Run after parent interface is configured
+
+help: Configure parameters for sending Router Advertisements (RAs)
+
+end:
+	if [ "$COMMIT_ACTION" = "SET" -o "$COMMIT_ACTION" = "ACTIVE" ]; then
+	    echo "Re-generating radvd config file for interface $VAR(../../@)..."
+	    sudo /opt/vyatta/sbin/vyatta_gen_radvd.pl --generate $VAR(../../@)
+	    if [ $? != 0 ]; then
+		exit 1
+	    fi
+	elif [ "$COMMIT_ACTION" = "DELETE" ]; then
+	    echo "Deleting entry for interface $VAR(../../@) from radv config file..."
+	    sudo /opt/vyatta/sbin/vyatta_gen_radvd.pl --delete $VAR(../../@)
+	    if [ $? != 0 ]; then
+		exit 1
+	    fi
+	fi
+
+	if [ -e /var/run/radvd/radvd.pid ]; then
+	    if [ -s /etc/radvd.conf ]; then
+		echo "Re-starting radvd..."
+		sudo /etc/init.d/radvd stop
+		sudo /etc/init.d/radvd start
+	    else
+		echo "Stopping radvd..."
+		sudo /etc/init.d/radvd stop
+	    fi
+	else
+	    if [ -s /etc/radvd.conf ]; then
+		echo "Starting radvd..."
+		sudo /etc/init.d/radvd start
+	    else
+		echo "Not starting radvd."
+	    fi
+	fi

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/other-config-flag/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/other-config-flag/node.def
@@ -1,0 +1,9 @@
+type: bool
+help: Value to be placed in the "other configuration" flag in RAs
+
+# Default value per RFC-4861.
+default: false
+allowed: echo -n "true false"
+
+val_help: true; Place "true" in "other configuration" flag in RAs
+val_help: false; Place "false" in "other configuration" flag in RAs

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.def
@@ -1,0 +1,7 @@
+tag:
+type: ipv6net
+
+help: IPv6 prefix to be advertised in Router Advertisements (RAs)
+
+val_help: ipv6net; IPv6 prefix to be advertized in Router Advertisements (RAs)
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/autonomous-flag/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/autonomous-flag/node.def
@@ -1,0 +1,9 @@
+type: bool
+
+help: Whether prefix can be used for address auto-configuration
+
+# Default value per RFC-4861.
+default: true
+
+val_help: true; Prefix can be used for stateless address auto-configuration
+val_help: false; Prefix can not be used for stateless address auto-configuration

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/on-link-flag/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/on-link-flag/node.def
@@ -1,0 +1,9 @@
+type: bool
+help: Flag that prefix can be used for on-link determination
+
+# Default value per RFC-4861.
+default: true
+
+val_help: true; Prefix can be used for on-link determination
+val_help: false; Prefix can not be used for on-link determination
+

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/preferred-lifetime/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/preferred-lifetime/node.def
@@ -1,0 +1,11 @@
+type: txt
+help: Time in seconds that the prefix will remain preferred
+
+# Default value will be set by back-end script based on value of
+# AdvValidLifetime following guidelines in RFC-4861 if this value 
+# is left unspecified by the user.
+
+val_help: <0-MAX>; Time in seconds that the prefix will remain preferred
+val_help: infinity; Prefix will remain preferred forever
+
+syntax:expression: ($VAR(@) == "infinity" || (pattern $VAR(@) "[0-9]*")) ; "Must be 'infinity' or a number"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/valid-lifetime/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/prefix/node.tag/valid-lifetime/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Time in seconds that the prefix will remain valid
+
+# Default per RFC-4861.
+default: "2592000"
+
+val_help: <0-MAX>; Time in seconds that the prefix will remain valid
+val_help: infinity; Prefix will remain valid forever
+
+syntax:expression: ($VAR(@) == "infinity" || (pattern $VAR(@) "[0-9]*")) ; "Must be 'infinity' or a number"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/radvd-options/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/radvd-options/node.def
@@ -1,0 +1,3 @@
+multi:
+type: txt
+help: Options for radvd

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/reachable-time/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/reachable-time/node.def
@@ -1,0 +1,9 @@
+type: u32
+help: Value to be placed in "Reachable Time" field in RAs
+
+default: 0
+
+val_help: u32:1-3600000; Reachable Time value in RAs (in milliseconds)
+val_help: 0; Reachable Time 0 (i.e., unspecified by this router)
+
+syntax:expression: ($VAR(@) >= 0 && $VAR(@) <= 3600000) ; "Value must be between 0 and 3,600,000 milliseconds (1 hour)"

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/retrans-timer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/retrans-timer/node.def
@@ -1,0 +1,7 @@
+type: u32
+help: Value to place in "Retrans Timer" field in RAs.
+
+default: 0
+
+val_help: <1-MAX>; Value in milliseconds to place in "Retrans Timer" field in RAs
+val_help: 0; Place 0, meaning "unspecified", in in "Retrans Timer" field in RAs

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/send-advert/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/ipv6/router-advert/send-advert/node.def
@@ -1,0 +1,16 @@
+type: bool
+
+help: Enable/disable sending RAs
+
+# RFC-4861 default value is false, but since the router-advert tree is
+# absent by default, that serves to meet the requirement that router
+# adverts not be sent unless the system administrator explicitly configures
+# the router to send them.  So, configuring router-advert and leaving
+# this value unspecified serves to enable sending route adverts.
+
+default: true
+allowed: echo -n "true false"
+
+val_help: true; Enable sending RAs
+val_help: false; Disable sending RAs
+


### PR DESCRIPTION
Current ip & ipv6 interface settings templates generated by script in vyatta-cfg package. These templates apply settings with scripts in the templates. Ubnt standard is to instead apply the settings using the ubnt-interface.pl script. This PR removes the vyatta-cfg package generated templates and replaces them with the standard ubnt templates for ip & ipv6. ubnt-interface.pl script is already being called in the wireguard node.def.