### PR TITLE
Use vyatta scripts to assign addresses once interface is up

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/address/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/address/node.def
@@ -1,12 +1,14 @@
 multi:
-type: txt
+priority: 999 # Run after interface has been configured
+type: ipv4net,ipv6net
+val_help: ipv4net; IPv4 address and prefix length
+val_help: ipv6net; IPv6 address and prefix length
 help: IP address
 
 syntax:expression: exec "/opt/vyatta/sbin/valid_address $VAR(@)"
 
-create: sudo ip addr add $VAR(@) dev $VAR(../@)
+commit:expression: exec "sudo /opt/vyatta/sbin/vyatta-interfaces.pl --valid-addr-commit $VAR(@@) --dev $VAR(../@)"
 
-delete: sudo ip addr del $VAR(@) dev $VAR(../@)
+create: sudo /opt/vyatta/sbin/vyatta-address add $VAR(../@) $VAR(@)
 
-val_help: ipv4net; IP address and prefix length
-val_help: ipv6net; IPv6 address and prefix length
+delete: sudo /opt/vyatta/sbin/vyatta-address delete $VAR(../@) $VAR(@)


### PR DESCRIPTION
Instead of calling `ip addr` directly use vyatta scripts to set interface addresses. The vyatta scripts perform validation such as making sure ip addresses aren't assigned to another interface. Also set the priority for assigning ip addresses to 999 to make sure they are done after the wireguard interface is up. Unlike IPv4 addresses IPv6 addresses are lost when the link is taken down as occurs during a commit, so they must be assigned after the interface is back up.