### PR TITLE
Portability changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+TAR ?= tar
+AR ?= ar
+
 all: deb-e50 deb-e100 deb-e200 deb-e300 deb-e1000
 
 clean:
@@ -5,12 +8,12 @@ clean:
 
 define gen_deb
 	mkdir -p package/scratch
-        tar --owner=root:0 --group root:0 -czf package/scratch/data.tar.gz -C generic . -C ../$(1) .
+        $(TAR) --owner=root:0 --group root:0 -czf package/scratch/data.tar.gz -C generic . -C ../$(1) .
 	cp -a debian package/scratch/
 	sed -i "s/Architecture: .*/Architecture: $(2)/" package/scratch/debian/control
-        tar --owner=root:0 --group root:0 -czf package/scratch/control.tar.gz -C package/scratch/debian .
+        $(TAR) --owner=root:0 --group root:0 -czf package/scratch/control.tar.gz -C package/scratch/debian .
         echo 2.0 > package/scratch/debian-binary
-        ar -rcs package/$(shell sed -n 's/Version: \(.*\)/wireguard-$(1)-\1.deb/p' debian/control) package/scratch/debian-binary package/scratch/data.tar.gz package/scratch/control.tar.gz
+        $(AR) -rcs package/$(shell sed -n 's/Version: \(.*\)/wireguard-$(1)-\1.deb/p' debian/control) package/scratch/debian-binary package/scratch/data.tar.gz package/scratch/control.tar.gz
         rm -rf package/scratch
 endef
 

--- a/update_binaries.sh
+++ b/update_binaries.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 declare -A BOARDS
 BOARDS[e50]=mipsel
 BOARDS[e100]=mips


### PR DESCRIPTION
My main platform is a MacBook and although I usually ssh to a linux box to do my work on vyatta-wireguard sometimes I do need to use the MacBook directly. These changes make it easier to build the package on POSIX like but non-Linux platforms.

update_binaries.sh shebang changed to use '/usr/bin/env bash' instead of '/bin/bash' which causes the path to be searched for bash. MacOS unfortunately ships with bash version 3 in /bin and bash version 4 needs to be installed using Homebrew or Macports.

Makefile allows using TAR and AR environment variables to specify tar and ar commands to use. Allows use of the Makefile on platforms which don't use the GNU versions by default. If not specified than 'tar' and 'ar' used by default. 