### PR TITLE
Fix #49 wg configuration not updating

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -1,4 +1,5 @@
 tag:
+priority: 920
 type: txt
 help: Peer public key
 

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/endpoint/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/endpoint/node.def
@@ -1,3 +1,2 @@
-priority: 9999
 type: txt
 help: Remote endpoint


### PR DESCRIPTION
Remove priority 9999 from endpoint template and add priority 920
to peer template. 920 is after all services which may affect
name resolution have started. Needed in case endpoint is a
host name and not an ip.