### PR TITLE
Fixes 2 bugs in the verification of allowed-ips against existing routes.

### DIFF
--- a/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
+++ b/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
@@ -83,7 +83,7 @@ sub check_peer {
     }
     
     $config->setLevel("interfaces wireguard ${intf}");
-    if ($config->returnValue("route-allowed-ips") == "true") {
+    if ($config->returnValue("route-allowed-ips") eq "true") {
         my $conflict = check_routes(@allowed_ips);
         if ($conflict) {
             die "Error: Allowed IP " . $conflict . " on interface ${intf} peer ${peer} conflicts with an existing route. route-allowed-ips cannot be enabled.\n";

--- a/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
+++ b/generic/opt/vyatta/sbin/vyatta-check-allowed-ips.pl
@@ -101,7 +101,7 @@ sub check_routes {
     chomp @routes;
 
     foreach my $ip (@allowed_ips) {
-       $ip = "default" if $ip = "0.0.0.0/0";
+       $ip = "default" if $ip eq "0.0.0.0/0";
        return $ip if grep { /^$ip/ } @routes;
     }
     return;


### PR DESCRIPTION
Fixes to errors in the code verify allowed-ips against existing routes. The first causes the check to be performed even when route-allowed-ips is false and the second causes all allowed-ips to be checked as if they were 0.0.0.0/0.