### PR TITLE
Delete routes when peer or allowed-ip removed

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.def
@@ -13,6 +13,11 @@ commit:expression: exec "${vyatta_sbindir}/vyatta-check-allowed-ips.pl --intf $V
 end:
         if [ "$COMMIT_ACTION" = DELETE ] || [ -n "$VAR(./disable)" ]; then
           if [[ $(sudo wg show "$VAR(../@)" peers) == *"$VAR(@)"* ]]; then
+            if [ "$VAR(../route-allowed-ips/@)" == "true" ]; then
+              for allowed_ip in $(sudo wg show $VAR(../@) allowed-ips | awk '$1=="$VAR(@)" {$1=""; print $0}'); do
+                sudo ip route del "$allowed_ip" dev $VAR(../@) 2> /dev/null
+              done
+            fi
             sudo wg set $VAR(../@) peer "$VAR(@)" remove
           fi
         else

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/peer/node.tag/allowed-ips/node.def
@@ -3,5 +3,13 @@ type: txt
 help: IP addresses allowed to traverse the peer
 val_help: <x.x.x.x/x | h:h:h:h:h:h:h:h>[,x.x.x.x/x | h:h:h:h:h:h:h:h]...; Comma separated list of IP addresses to allow
 
+delete:
+       if [ "$VAR(../../route-allowed-ips/@)" == "true" ]; then
+         ips="$VAR(@)"
+         for ip in ${ips//,/ }; do
+           sudo ip route del "$ip" dev "$VAR(../../@)" 2> /dev/null
+         done
+       fi
+
 syntax:expression: exec "ips=$VAR(@); for ip in ${ips//,/ }; do /opt/vyatta/sbin/vyatta-find-type.pl $ip ipv4net ipv4 ipv6net ipv6 > /dev/null; done || exit 1";
                    "Value must contain valid IP addresses"


### PR DESCRIPTION
If route-allowed-ips is true remove created routes if the peer they are associated with is removed, either deleted or disabled, or the allowed-ip is removed from a peer. Fixes #55 