### PR TITLE
Update Vyatta/Interface.pm to v1.10.5

### DIFF
--- a/generic/opt/vyatta/share/perl5/Vyatta/Interface.pm
+++ b/generic/opt/vyatta/share/perl5/Vyatta/Interface.pm
@@ -264,7 +264,7 @@ sub new {
         my $vifpath = $net_prefix{$prefix}{vif};
 
         # Interface name has vif, but this type doesn't support vif!
-        return if ( $vif && !$vifpath );
+        return if ( defined($vif) && !$vifpath );
 
         # Check path if given
         return if ( $#_ >= 0 && join( ' ', @_ ) ne $type );


### PR DESCRIPTION
Release v1.10.5 fixes interface verification helper to support where `vif 0` is valid interface. Although 0 is not a valid 802.1Q VLAN Id, it's used to tag traffic to look like IEEE P802.1p priority tagging. A mandatory configuration for most fiber optic WAN (FTTx) setups.

For reference: Issue and fix acknowledged by UBNT employee -- https://community.ubnt.com/t5/EdgeRouter/DHCPv6-PD-doesn-t-generate-config-for-WAN-VLANs/m-p/2344103#M207768