### PR TITLE
Update Vyatta/Interface.pm to v1.10.5 -- Take 2

### DIFF
--- a/generic/opt/vyatta/share/perl5/Vyatta/Interface.pm
+++ b/generic/opt/vyatta/share/perl5/Vyatta/Interface.pm
@@ -270,7 +270,7 @@ sub new {
         return if ( $#_ >= 0 && join( ' ', @_ ) ne $type );
 
         my $path = "interfaces $type $dev";
-        $path .= " $vifpath $vif" if $vif;
+        $path .= " $vifpath $vif" if defined($vif);
 
 	my $self = {
 	    name => $name,


### PR DESCRIPTION
Fix previously botched version sync.

The change in v1.10.5 is actually two lines. Instead of copying
over `Interface.pm` from squashfs and adding `wg` entry to
`%net_prefix`, I fixed two lines in the repo.  This was prone to various
editor errors and here we are.  This time, done it the way I should've
done in the first place.