### PR TITLE
Makefile: switch the order of control.tar.gz and data.tar.gz in the deb archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ define gen_deb
 	sed -i "s/Architecture: .*/Architecture: $(2)/" package/scratch/debian/control
         $(TAR) --owner=root:0 --group root:0 -czf package/scratch/control.tar.gz -C package/scratch/debian .
         echo 2.0 > package/scratch/debian-binary
-        $(AR) -rcs package/$(shell sed -n 's/Version: \(.*\)/wireguard-$(1)-\1.deb/p' debian/control) package/scratch/debian-binary package/scratch/data.tar.gz package/scratch/control.tar.gz
+        $(AR) -rcs package/$(shell sed -n 's/Version: \(.*\)/wireguard-$(1)-\1.deb/p' debian/control) package/scratch/debian-binary package/scratch/control.tar.gz package/scratch/data.tar.gz
         rm -rf package/scratch
 endef
 


### PR DESCRIPTION
According to deb(5), control.tar(.gz) must come before data.tar(.gz) in
the archive, but the Makefile here has the order backwards. The dpkg
version in Wheezy apparently didn't care about this, but newer dpkg in
Stretch fails with the error:

    dpkg-deb: error: archive 'wireguard-e300-0.0.20181218-1.deb' has
      premature member 'data.tar.gz' before 'control.tar', giving up

Fixes: https://github.com/Lochnair/vyatta-wireguard/issues/76