### PR TITLE
Add up/down script. See issue #136

### DIFF
--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.def
@@ -8,13 +8,17 @@ syntax:expression: pattern $VAR(@) "^wg[0-9]+$" \
 
 create: ip link show dev $VAR(@) &>/dev/null || sudo ip link add dev $VAR(@) type wireguard
 
-delete: sudo ip link del dev $VAR(@)
+delete: (eval "$VAR(down-command/@)" >/dev/null || exit 1) && sudo ip link del dev $VAR(@)
 
-end: if [ "$COMMIT_ACTION" != DELETE ]; then
-	sudo ip link set down dev $VAR(@)
+end:
+     if [ "$COMMIT_ACTION" != DELETE ]; then
+        eval "$VAR(down-command/@) >/dev/null" || exit 1;
+        sudo ip link set down dev $VAR(@)
         if [ ! -n "$VAR(./disable)" ]; then
           sudo ip link set up dev $VAR(@)
+          eval "$VAR(up-command/@) >/dev/null" || exit 1;
           if [ "$VAR(route-allowed-ips/@)" == "true" ]; then
+            [ -n "$VAR(./route-table)" ] && tnum="$VAR(./route-table/@)"
             for i in $(sudo wg show $VAR(@) allowed-ips | sed 's/^.*\t//;s/ /\n/g' | sort -nr -k 2 -t /); do
              if [ $i == "(none)" ]; then continue; fi
              [[ $(sudo ip route get "$i" 2>/dev/null) == *dev\ $VAR(@)\ * ]] || sudo ip route add "$i" dev $VAR(@)

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/down-command/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/down-command/node.def
@@ -1,0 +1,4 @@
+type: txt
+help: Script or command executed before the interface goes down
+val_help: txt; Command
+val_help: txt; Executable script in /config/scripts

--- a/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/up-command/node.def
+++ b/generic/opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard/node.tag/up-command/node.def
@@ -1,0 +1,4 @@
+type: txt
+help: Script or command executed after the interface went up
+val_help: txt; Command
+val_help: txt; Executable script in /config/scripts


### PR DESCRIPTION
This change allows to add a up/down command: This makes is possible to add some ip rules or routes to the routing table for example without having to write a script manually.
- After interface creation (like on boot, or first config creation) the up-script will be executed
- Before Interface deletion (delete the config entry) the down-script will be executed
- On every commit the down-script followed by the up-script will be executed

If either the down or up command fails the whole commit of this wireguard node will fail. To prevent this default behavior for some special cases just add a `(...) || true` at the end of your command.